### PR TITLE
Drop kB multiplier for cache size and check error.

### DIFF
--- a/src/l3.c
+++ b/src/l3.c
@@ -99,8 +99,12 @@ int main(int argc, char **argv) {
 		printf("Usage: ./l3 <duration in sec>\n"); 
 		exit(0); 
 	}	
-	block = (char*)mmap(NULL, CACHE_SIZE * 1024, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
-
+	block = (char*)mmap(NULL, CACHE_SIZE, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+	if (block == (char *) -1) {
+		perror("error: cannot mmap");
+		exit(1);
+	};
+	
 	int usr_timer = atoi(argv[1]);
 	double time_spent = 0.0; 
   	clock_t begin, end;


### PR DESCRIPTION
cache_size helper already returns values in bytes (mmap cannot allocate too much).
Fixes #5.